### PR TITLE
delete port field when init sequelize

### DIFF
--- a/app/database.js
+++ b/app/database.js
@@ -4,7 +4,6 @@ var db = {}
 
 const sequelize = new Sequelize('graphql-mysql-tutorial', 'graphql', '123456', {
     host: 'localhost',
-    port: '8006',
     dialect: 'mysql',
     define: {
         freezeTableName: true,


### PR DESCRIPTION
Hi Mate,

When I do this on my local follow your tutorial, I got some connection error when init the sequelize with setting port filed.
And when removed this,  connection worked well. 
port: '8006'